### PR TITLE
ba-96 Implement method to reset the checkbox of the search bar in the socobo-element-search

### DIFF
--- a/app/elements/socobo-element-search/socobo-element-search.html
+++ b/app/elements/socobo-element-search/socobo-element-search.html
@@ -171,6 +171,8 @@ Custom property | Description | Default
         resetQuery: function() {
           this.searchStr = "";
           this.searchQueryChanged();
+          this.$.chbCheckAllItems.checked = false;
+          this.fire("uncheck-all-items");
         },
         /**
          * Method for clear search query and firing event. </br>
@@ -182,7 +184,7 @@ Custom property | Description | Default
           } else {
             this.searchStr = "";
           }
-          this.fire("changed-search-query", { searchQuery: this.searchStr });
+          this.searchQueryChanged();
         },
         /**
          * Method for show / hide search input container. </br>

--- a/app/elements/socobo-element-search/socobo-element-search.html
+++ b/app/elements/socobo-element-search/socobo-element-search.html
@@ -174,6 +174,17 @@ Custom property | Description | Default
           this.$.chbCheckAllItems.checked = false;
           this.fire("uncheck-all-items");
         },
+
+        /**
+         * Method to reset cjeckbox
+         * @method resetCheckbox
+         */
+        resetCheckbox: function() {
+          if (this.$.chbCheckAllItems.checked) {
+            this.$.chbCheckAllItems.checked = false;
+          }
+        },
+
         /**
          * Method for clear search query and firing event. </br>
          * @method _clearSearchQuery

--- a/app/elements/socobo-element-search/socobo-element-search.html
+++ b/app/elements/socobo-element-search/socobo-element-search.html
@@ -163,6 +163,15 @@ Custom property | Description | Default
         searchQueryChanged: function() {
           this.fire("changed-search-query", { searchQuery: this.searchStr });
         },
+
+        /**
+         * Method for resetting the search query </br>
+         * @method resetQuery
+         */
+        resetQuery: function() {
+          this.searchStr = "";
+          this.searchQueryChanged();
+        },
         /**
          * Method for clear search query and firing event. </br>
          * @method _clearSearchQuery
@@ -171,9 +180,9 @@ Custom property | Description | Default
           if (this.$.txtSearchQuery.value.length === 0) {
             this._toggleSearchElements();
           } else {
-            this.$.txtSearchQuery.value = "";
-            this.fire("changed-search-query", { searchQuery: null });
+            this.searchStr = "";
           }
+          this.fire("changed-search-query", { searchQuery: this.searchStr });
         },
         /**
          * Method for show / hide search input container. </br>

--- a/app/test/socobo-element-search/socobo-element-search.html
+++ b/app/test/socobo-element-search/socobo-element-search.html
@@ -43,7 +43,7 @@
         done();
       });
 
-      test("has a reset method", function(done) {
+      test("has a reset query method", function(done) {
         expect(socoboElementSearch.resetQuery).to.not.be.eql(undefined);
         done();
       });
@@ -85,6 +85,18 @@
 
         expect(socoboElementSearch.$.searchInputContainer.classList.contains("style-search-input-container"))
           .to.be.eql(true, "style-search-input-container");
+        done();
+      });
+
+      test("has a reset checkbox method", function(done) {
+        expect(socoboElementSearch.resetCheckbox).to.not.be.eql(undefined);
+        done();
+      });
+
+      test("calling reset checkbox method to uncheck checkbox", function(done) {
+        socoboElementSearch.$.chbCheckAllItems.checked = true;
+        socoboElementSearch.resetCheckbox();
+        expect(socoboElementSearch.$.chbCheckAllItems.checked).to.be.eql(false);
         done();
       });
 

--- a/app/test/socobo-element-search/socobo-element-search.html
+++ b/app/test/socobo-element-search/socobo-element-search.html
@@ -57,6 +57,17 @@
         socoboElementSearch.resetQuery();
       });
 
+      test("calling reset fires an uncheck all event", function(done) {
+        socoboElementSearch.addEventListener("uncheck-all-items", function(e) {
+          expect(socoboElementSearch.$.chbCheckAllItems.checked).to.be.eql(false);
+          done();
+        });
+
+        socoboElementSearch.$.chbCheckAllItems.checked = true;
+        socoboElementSearch.resetQuery();
+
+      });
+
       test("calling reset on hidden search bar does not toggle the search bar", function(done) {
         expect(socoboElementSearch.$.searchInputContainer.classList.contains("hide-search-input-container")).to.be.eql(true);
         socoboElementSearch.resetQuery();

--- a/app/test/socobo-element-search/socobo-element-search.html
+++ b/app/test/socobo-element-search/socobo-element-search.html
@@ -43,6 +43,40 @@
         done();
       });
 
+      test("has a reset method", function(done) {
+        expect(socoboElementSearch.resetQuery).to.not.be.eql(undefined);
+        done();
+      });
+
+      test("calling reset fires an changed-search-query event", function(done) {
+        socoboElementSearch.addEventListener("changed-search-query", function(e) {
+          expect(e.detail.searchQuery).to.be.eql("");
+          done();
+        });
+
+        socoboElementSearch.resetQuery();
+      });
+
+      test("calling reset on hidden search bar does not toggle the search bar", function(done) {
+        expect(socoboElementSearch.$.searchInputContainer.classList.contains("hide-search-input-container")).to.be.eql(true);
+        socoboElementSearch.resetQuery();
+
+        expect(socoboElementSearch.$.searchInputContainer.classList.contains("hide-search-input-container")).to.be.eql(true);
+        done();
+
+      });
+
+      test("tapping search buttons shows the search input", function (done) {
+        MockInteractions.tap(socoboElementSearch.$.btnSearch);
+
+        expect(socoboElementSearch.$.searchInputContainer.classList.contains("hide-search-input-container"))
+          .to.be.eql(false, "hide-search-input-container");
+
+        expect(socoboElementSearch.$.searchInputContainer.classList.contains("style-search-input-container"))
+          .to.be.eql(true, "style-search-input-container");
+        done();
+      });
+
     });
   </script>
 </body>


### PR DESCRIPTION
ba-96 Implement method to reset the checkbox of the search bar in the socobo-element-search

Add resetQuery method to the public API of the search element
Reset the search string in this method
Use double data-binding to reflect changes to the input
