### PR TITLE
ba-104 only remove visible recipes

### DIFF
--- a/app/elements/socobo-recipe/socobo-recipe-overview.html
+++ b/app/elements/socobo-recipe/socobo-recipe-overview.html
@@ -576,7 +576,11 @@ Custom property | Description | Default
           if(item.info !== undefined){
             checkInfo = !((item.info).toLowerCase().indexOf(lowerCaseQuery) != -1);
           }
-          return checkDesc || checkInfo;
+          var result = checkDesc || checkInfo;
+          if(result){
+            this._updateAfterDeletion(item, this._checkedBoxes.refs, "_checkedBoxes.refs");
+          }
+          return result;
         }
       });
     })();


### PR DESCRIPTION
Should fix the bug with removing checked recipes which are not longer visible because of corresponding search query. Now only visible and checked recipes are removed.
