### PR TITLE
ba-106 Fix bug with restoring the measurement on opening the edit dialog

### DIFF
--- a/app/elements/socobo-inventory/socobo-inventory-create.html
+++ b/app/elements/socobo-inventory/socobo-inventory-create.html
@@ -201,11 +201,12 @@ Custom property | Description | Default
 
         _resetItem: function(item) {
           if (item != undefined) {
+            console.log("ITEM",item);
             this.item = item;
             this.$.bestBeforeInput.value = item.bestBefore;
             this.$.categoryDropdownMenu.select(this.categories.indexOf(item.category));
             this.measurements.forEach(function(measurement, index) {
-              if (this.measurements.indexOf(item.measurement) !== -1) {
+              if (measurement.value === item.measurement.value) {
                 this.$.measurementDropdownMenu.select(index);
               }
             }.bind(this));


### PR DESCRIPTION
Using objects for the measurements breaks the resetItem method of inventory-create. Because this method performs on the bare strings. If we use objects we have to access these strings over the value attribute what prevents us from using the indexOf method.
So we need to iterate over the measurements and do an equality test.
@lyio @flashback2k14 
