### PR TITLE
ba-117 Create Element for Toasts

### DIFF
--- a/app/elements/demo/socobo-element-toast/demo.html
+++ b/app/elements/demo/socobo-element-toast/demo.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/html">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>socobo-element-list-item Demo</title>
+    <link rel="import" href="elements.html">
+    <style>
+      .buttons {
+      }
+    </style>
+  </head>
+  <body>
+  <template is="dom-bind" id="demo">
+    <paper-button class="buttons" on-tap="successToast">Success</paper-button>
+    <paper-button class="buttons" on-tap="plainToast">Plain</paper-button>
+    <paper-button class="buttons" on-tap="errorToast">Failure</paper-button>
+    <paper-button class="buttons" on-tap="spinnerStartToast">Spinner start</paper-button>
+    <paper-button class="buttons">Spinner stop</paper-button>
+    <socobo-element-toast></socobo-element-toast>
+  </template>
+
+  <script type="text/javascript">
+    var demo = document.querySelector("#demo");
+
+    demo.successToast = function() {
+      this.fire("socobo-show-toast", {type: "success", duration: 2000, message: "Success!"});
+    };
+    demo.errorToast = function() {
+      this.fire("socobo-show-toast", {type: "error", duration: 2000, message: "Error!"});
+    };
+
+    demo.plainToast = function() {
+      this.fire("socobo-show-toast", {type: "plain", duration: 2000, message: "Info!"});
+    };
+
+    demo.spinnerStartToast = function() {
+      this.fire("socobo-show-toast", {type: "spinner", duration: 2000, message: "Loading!"});
+    };
+  </script>
+  </body>
+</html>

--- a/app/elements/demo/socobo-element-toast/elements.html
+++ b/app/elements/demo/socobo-element-toast/elements.html
@@ -1,0 +1,20 @@
+<!-- Web Components -->
+<script src="../../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+<!-- Polymer -->
+<link rel="import" href="../../../bower_components/polymer/polymer.html">
+<!-- Iron Elements -->
+<link rel="import" href="../../../bower_components/iron-icons/iron-icons.html">
+<link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout.html">
+<!-- Paper Elements -->
+<link rel="import" href="../../../bower_components/paper-checkbox/paper-checkbox.html">
+<link rel="import" href="../../../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../../../bower_components/paper-material/paper-material.html">
+<link rel="import" href="../../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../../../bower_components/paper-dialog/paper-dialog.html">
+<link rel="import" href="../../../bower_components/paper-toast/paper-toast.html">
+<!-- Neon Elements -->
+<link rel="import" href="../../../bower_components/neon-animation/neon-animation-runner-behavior.html">
+<link rel="import" href="../../../bower_components/neon-animation/animations/fade-in-animation.html">
+<!-- Socobo List Item Elements -->
+<link rel="import" href="../../socobo-element-toast/socobo-element-toast.html">

--- a/app/elements/demo/socobo-element-toast/elements.html
+++ b/app/elements/demo/socobo-element-toast/elements.html
@@ -2,19 +2,7 @@
 <script src="../../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
 <!-- Polymer -->
 <link rel="import" href="../../../bower_components/polymer/polymer.html">
-<!-- Iron Elements -->
-<link rel="import" href="../../../bower_components/iron-icons/iron-icons.html">
-<link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout.html">
 <!-- Paper Elements -->
-<link rel="import" href="../../../bower_components/paper-checkbox/paper-checkbox.html">
-<link rel="import" href="../../../bower_components/paper-item/paper-item.html">
-<link rel="import" href="../../../bower_components/paper-material/paper-material.html">
-<link rel="import" href="../../../bower_components/paper-button/paper-button.html">
-<link rel="import" href="../../../bower_components/paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../../../bower_components/paper-dialog/paper-dialog.html">
 <link rel="import" href="../../../bower_components/paper-toast/paper-toast.html">
-<!-- Neon Elements -->
-<link rel="import" href="../../../bower_components/neon-animation/neon-animation-runner-behavior.html">
-<link rel="import" href="../../../bower_components/neon-animation/animations/fade-in-animation.html">
-<!-- Socobo List Item Elements -->
+<!-- Socobo Toast Element -->
 <link rel="import" href="../../socobo-element-toast/socobo-element-toast.html">

--- a/app/elements/demo/socobo-recipe/demo.html
+++ b/app/elements/demo/socobo-recipe/demo.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <template is="dom-bind" id="demo">
+      <socobo-element-toast></socobo-element-toast>
       <socobo-recipe
         id="elDemoRecipe"
         user-login="{{userLogin}}">

--- a/app/elements/demo/socobo-recipe/elements.html
+++ b/app/elements/demo/socobo-recipe/elements.html
@@ -29,6 +29,7 @@
 <!-- Socobo Elements -->
 <link rel="import" href="../../socobo-element-list-item/socobo-element-list-item.html">
 <link rel="import" href="../../socobo-element-search/socobo-element-search.html">
+<link rel="import" href="../../socobo-element-toast/socobo-element-toast.html">
 <!-- Socobo Recipe Elements -->
 <link rel="import" href="../../socobo-recipe/socobo-recipe.html">
 <link rel="import" href="../../socobo-recipe/socobo-recipe-details-show.html">

--- a/app/elements/elements.html
+++ b/app/elements/elements.html
@@ -84,8 +84,10 @@
 <link rel="import" href="socobo-element-list-item/socobo-element-list-item.html">
 <!-- Socobo Search Elements -->
 <link rel="import" href="socobo-element-search/socobo-element-search.html">
-
+<!-- Socobo Button Elements-->
 <link rel="import" href="socobo-element-buttons/socobo-element-buttons.html">
+<!-- Socobo Element Toast -->
+<link rel="import" href="socobo-element-toast/socobo-element-toast.html">
 <!-- Socobo Ranking Elements -->
 <link rel="import" href="socobo-ranking/socobo-ranking.html">
 <link rel="import" href="socobo-ranking/socobo-ranking-dialog.html">

--- a/app/elements/socobo-element-toast/socobo-element-toast.html
+++ b/app/elements/socobo-element-toast/socobo-element-toast.html
@@ -82,7 +82,7 @@ Custom property | Description | Default
         /**
          * Add the correct style to the toast and remove any previously set ones
          *
-         * @param {DomElement} toast
+         * @param {HtmlElement} toast
          * @param {Object} msg
          * @private
          */

--- a/app/elements/socobo-element-toast/socobo-element-toast.html
+++ b/app/elements/socobo-element-toast/socobo-element-toast.html
@@ -38,7 +38,9 @@ Custom property | Description | Default
     </style>
 
     <div>
-      <paper-toast class="socobo-toast-plain" id="toast"></paper-toast>
+      <paper-toast
+        class="socobo-toast-plain"
+        id="toast"></paper-toast>
     </div>
   </template>
 
@@ -48,10 +50,20 @@ Custom property | Description | Default
         is: "socobo-element-toast",
 
         properties: {
+
+          /**
+           * Array to hold the queued up messages
+           *
+           * @private
+           */
           _messages: {
             type: Array,
             value: []
           }
+        },
+
+        listeners: {
+          "iron-overlay-closed": "_messageAdded"
         },
 
         observers: [
@@ -78,10 +90,10 @@ Custom property | Description | Default
          * @private
          */
         _styleToast: function(toast, msg) {
-          Array.from(toast.classList).filter(function(clazz) {
-            return clazz.indexOf("socobo-toast") !== -1;
-          }).forEach(function(c) {
-            toast.classList.remove(c);
+          toast.className.split(" ").forEach(function(clazz) {
+            if (clazz.indexOf("socobo-toast") !== -1) {
+              toast.classList.remove(clazz);
+            }
           });
           switch (msg.type) {
             case "success":
@@ -110,6 +122,7 @@ Custom property | Description | Default
             return msg.duration;
           }
         },
+
         /**
            * Observer for the _messages Array that handles changes to the array.
            * Displays the toast if no other toast is shown at the moment and queues up the message
@@ -125,7 +138,6 @@ Custom property | Description | Default
             this._toast.duration = this._extractDuration(msg);
 
             this._toast.show();
-            this.async(this._messageAdded, this._toast.duration);
           }
         },
         /**
@@ -135,6 +147,13 @@ Custom property | Description | Default
         ready: function() {
           this._toast = this.$.toast;
           window.addEventListener("socobo-show-toast", this._showToast.bind(this));
+
+          // Overriding the _renderClosed function of the paper-toast with the one from
+          // IronOverlayBehavior so the closed event is fired
+          this._toast._renderClosed = function() {
+            this.classList.remove('paper-toast-open');
+            Polymer.IronOverlayBehaviorImpl._renderClosed.apply(this, arguments);
+          }
         }
       });
     })();

--- a/app/elements/socobo-element-toast/socobo-element-toast.html
+++ b/app/elements/socobo-element-toast/socobo-element-toast.html
@@ -1,0 +1,142 @@
+<!--
+The following custom properties and mixins are available for styling:
+
+Custom property | Description | Default
+----------------|-------------|----------
+`--socobo-toast-style-error-notification-color` | Set background color for socobo-toast error notification | `{#EEEEEE}`
+`--socobo-toast-style-success-notification-color` | Set background color for socobo-toast success notification | `{#EEEEEE}`
+`--socobo-toast-style-plain-notification-color` | Set background color for socobo-toast info notification | `{#EEEEEE}`
+`--socobo-toast-style-spinner-notification-color` | Set background color for socobo-toast spinner notification | `{#EEEEEE}`
+`--socobo-recipe-style-notification-text-color` | Set the text color for the toasts | `{}`
+
+@demo demo/socobo-element-toast/demo.html
+-->
+<dom-module id="socobo-element-toast">
+  <template>
+    <style>
+      :host {
+        display: block;
+        font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
+      }
+
+      .socobo-toast-error {
+        --paper-toast-background-color: var(--socobo-toast-style-error-notification-color);
+        --paper-toast-color: var(--socobo-recipe-style-notification-text-color);
+      }
+      .socobo-toast-success {
+        --paper-toast-background-color: var(--socobo-toast-style-success-notification-color);
+        --paper-toast-color: var(--socobo-recipe-style-notification-text-color);
+      }
+      .socobo-toast-plain {
+         --paper-toast-background-color: var(--socobo-toast-style-plain-notification-color);
+         --paper-toast-color: var(--socobo-recipe-style-notification-text-color);
+       }
+      .socobo-toast-spinner {
+          --paper-toast-background-color: var(--socobo-toast-style-spinner-notification-color);
+          --paper-toast-color: var(--socobo-recipe-style-notification-text-color);
+        }
+    </style>
+
+    <div>
+      <paper-toast class="socobo-toast-plain" id="toast"></paper-toast>
+    </div>
+  </template>
+
+  <script>
+    (function() {
+      Polymer({
+        is: "socobo-element-toast",
+
+        properties: {
+          _messages: {
+            type: Array,
+            value: []
+          }
+        },
+
+        observers: [
+          "_messageAdded(_messages.splices)"
+        ],
+
+        _DEFAULT: 3000,
+        /**
+         * Handles the global toast events and decides which toast to show when
+         *
+         * @param {CustomEvent} e
+         * @private
+         * @function
+         */
+        _showToast: function(e) {
+          this.push("_messages", e.detail);
+        },
+
+        /**
+         * Add the correct style to the toast and remove any previously set ones
+         *
+         * @param {DomElement} toast
+         * @param {Object} msg
+         * @private
+         */
+        _styleToast: function(toast, msg) {
+          Array.from(toast.classList).filter(function(clazz) {
+            return clazz.indexOf("socobo-toast") !== -1;
+          }).forEach(function(c) {
+            toast.classList.remove(c);
+          });
+          switch (msg.type) {
+            case "success":
+              toast.classList.add("socobo-toast-success");
+              break;
+            case "error":
+              toast.classList.add("socobo-toast-error");
+              break;
+            case "spinner":
+              toast.classList.add("socobo-toast-spinner");
+              break;
+            default:
+              toast.classList.add("socobo-toast-plain");
+          }
+          this.updateStyles();
+        },
+
+        /**
+         * Extract the duration from the message object if it contains any.
+         * Defaults to a set default value. Disallows infinity.
+         */
+        _extractDuration: function(msg) {
+          if ((msg.duration && msg.duration < 1) || !msg.duration) {
+            return this._DEFAULT;
+          } else {
+            return msg.duration;
+          }
+        },
+        /**
+           * Observer for the _messages Array that handles changes to the array.
+           * Displays the toast if no other toast is shown at the moment and queues up the message
+           * if a toast is currently in progress.
+           *
+           * @private
+           */
+        _messageAdded: function() {
+          if (!this.$.toast.opened && this._messages.length) {
+            var msg = this._messages.shift(); // bypasses Polymer observers intentionally
+            this._toast.text = msg.message;
+            this._styleToast(this.$.toast, msg);
+            this._toast.duration = this._extractDuration(msg);
+
+            this._toast.show();
+            this.async(this._messageAdded, this._toast.duration);
+          }
+        },
+        /**
+         * Called when the component is ready. Adds an event listener for `socobo-show-toast`
+         * to the current window object, thus listening to this event globally.
+         */
+        ready: function() {
+          this._toast = this.$.toast;
+          window.addEventListener("socobo-show-toast", this._showToast.bind(this));
+        }
+      });
+    })();
+  </script>
+</dom-module>

--- a/app/elements/socobo-element-toast/socobo-element-toast.html
+++ b/app/elements/socobo-element-toast/socobo-element-toast.html
@@ -31,16 +31,13 @@ Custom property | Description | Default
          --paper-toast-background-color: var(--socobo-toast-style-plain-notification-color);
          --paper-toast-color: var(--socobo-recipe-style-notification-text-color);
        }
-      .socobo-toast-spinner {
-          --paper-toast-background-color: var(--socobo-toast-style-spinner-notification-color);
-          --paper-toast-color: var(--socobo-recipe-style-notification-text-color);
-        }
     </style>
 
     <div>
       <paper-toast
         class="socobo-toast-plain"
-        id="toast"></paper-toast>
+        id="toast">
+      </paper-toast>
     </div>
   </template>
 
@@ -102,9 +99,6 @@ Custom property | Description | Default
             case "error":
               toast.classList.add("socobo-toast-error");
               break;
-            case "spinner":
-              toast.classList.add("socobo-toast-spinner");
-              break;
             default:
               toast.classList.add("socobo-toast-plain");
           }
@@ -116,7 +110,7 @@ Custom property | Description | Default
          * Defaults to a set default value. Disallows infinity.
          */
         _extractDuration: function(msg) {
-          if ((msg.duration && msg.duration < 1) || !msg.duration) {
+          if ((msg.duration && msg.duration < 1) || !msg.duration || msg.duration === Infinity) {
             return this._DEFAULT;
           } else {
             return msg.duration;

--- a/app/elements/socobo-element-toast/socobo-element-toast.html
+++ b/app/elements/socobo-element-toast/socobo-element-toast.html
@@ -151,9 +151,9 @@ Custom property | Description | Default
           // Overriding the _renderClosed function of the paper-toast with the one from
           // IronOverlayBehavior so the closed event is fired
           this._toast._renderClosed = function() {
-            this.classList.remove('paper-toast-open');
+            this.classList.remove("paper-toast-open");
             Polymer.IronOverlayBehaviorImpl._renderClosed.apply(this, arguments);
-          }
+          };
         }
       });
     })();

--- a/app/elements/socobo-grocery-list/lib/socobo-grocery.js
+++ b/app/elements/socobo-grocery-list/lib/socobo-grocery.js
@@ -112,12 +112,23 @@ var SocoboGrocery = (function() {
       var removePath = new Firebase(_archiveItemsRoute + "/" + item.key);
       removePath.remove();
     };
+    /**
+     * unregister listener for tracking changes
+     */
+    var unregisterGroceryItemListeners = function() {
+      // active
+      _refActive.off("child_added");
+      _refActive.off("child_removed");
+      // archive
+      _refArchive.off("child_added");
+    };
 
     /**
      * Public API
      */
     return {
       registerGroceryItemListeners: registerGroceryItemListeners,
+      unregisterGroceryItemListeners: unregisterGroceryItemListeners,
       addItemToActiveList: addItemToActiveList,
       removeItemFromActiveList: removeItemFromActiveList,
       addItemToArchiveList: addItemToArchiveList,

--- a/app/elements/socobo-grocery-list/socobo-grocery-list.html
+++ b/app/elements/socobo-grocery-list/socobo-grocery-list.html
@@ -356,7 +356,7 @@ Custom property | Description | Default
             this._notify({
               type: "plain",
               duration: 2000,
-              message: "There is no Active Item checked for unchecking."
+              message: "There is no active Item checked for unchecking."
             });
           }
         },
@@ -472,7 +472,7 @@ Custom property | Description | Default
               this._notify({
                 type: "error",
                 duration: 2000,
-                message: "There Item is not available."
+                message: "There is no Item available."
               });
             }
           } else {
@@ -480,7 +480,7 @@ Custom property | Description | Default
             this._notify({
               type: "plain",
               duration: 2000,
-              message: "There Item is not checked. Please check the Item before delete."
+              message: "There is no checked Item. Please check the Item before delete."
             });
           }
         },
@@ -514,7 +514,7 @@ Custom property | Description | Default
             this._notify({
               type: "error",
               duration: 2000,
-              message: "There Item is not available."
+              message: "There is no Item available."
             });
           }
         },
@@ -542,7 +542,7 @@ Custom property | Description | Default
             this._notify({
               type: "error",
               duration: 2000,
-              message: "There Item is not available."
+              message: "There is no Item available."
             });
           }
         },
@@ -572,7 +572,7 @@ Custom property | Description | Default
             this._notify({
               type: "error",
               duration: 2000,
-              message: "There Item is not available."
+              message: "There is no Item available."
             });
           }
         },

--- a/app/elements/socobo-grocery-list/socobo-grocery-list.html
+++ b/app/elements/socobo-grocery-list/socobo-grocery-list.html
@@ -354,8 +354,7 @@ Custom property | Description | Default
             items.splice(checkItemIndex, 1);
           } else {
             this._notify({
-              type: "plain",
-              duration: 2000,
+              type: "error",
               message: "There is no active Item checked for unchecking."
             });
           }
@@ -471,15 +470,13 @@ Custom property | Description | Default
               // notify user
               this._notify({
                 type: "error",
-                duration: 2000,
                 message: "There is no Item available."
               });
             }
           } else {
             // notify user
             this._notify({
-              type: "plain",
-              duration: 2000,
+              type: "error",
               message: "There is no checked Item. Please check the Item before delete."
             });
           }
@@ -513,7 +510,6 @@ Custom property | Description | Default
             // notify user
             this._notify({
               type: "error",
-              duration: 2000,
               message: "There is no Item available."
             });
           }
@@ -541,7 +537,6 @@ Custom property | Description | Default
             // notify user
             this._notify({
               type: "error",
-              duration: 2000,
               message: "There is no Item available."
             });
           }
@@ -571,7 +566,6 @@ Custom property | Description | Default
             // notify user
             this._notify({
               type: "error",
-              duration: 2000,
               message: "There is no Item available."
             });
           }
@@ -677,7 +671,6 @@ Custom property | Description | Default
         _groceryChangedError: function(error) {
           this._notify({
             type: "error",
-            duration: 2000,
             message: "Grocery List - Error: " + error.code + " - " + error.message
           });
         },

--- a/app/elements/socobo-grocery-list/socobo-grocery-list.html
+++ b/app/elements/socobo-grocery-list/socobo-grocery-list.html
@@ -134,8 +134,6 @@ Custom property | Description | Default
         </div>
       </iron-pages>
     </div>
-    <!-- Notification-->
-    <paper-toast id="infoGroceryList" duration="2000"></paper-toast>
   </template>
 
   <script>
@@ -211,7 +209,15 @@ Custom property | Description | Default
               .addItemToActiveList({desc: item.desc + " - " + item.amount + " " + item.unit});
           }.bind(this));
         },
-
+        /**
+         * unregister tracking changed listeners
+         * 
+         * @function
+         */
+        unregisterListeners: function() {
+          SocoboGrocery.getInstance(this, this.userLogin).unregisterGroceryItemListeners();
+        },
+        
         /**
          * PRIVATE API
          */
@@ -347,7 +353,12 @@ Custom property | Description | Default
           if (checkItemIndex !== -1) {
             items.splice(checkItemIndex, 1);
           } else {
-            this._notify("There is no Active Item checked for unchecking.");
+            var msgObj = {
+              type: "plain", 
+              duration: 2000, 
+              message: "There is no Active Item checked for unchecking."
+            };
+            this.fire("socobo-show-toast", msgObj);
           }
         },
 
@@ -459,11 +470,21 @@ Custom property | Description | Default
               }
             } else {
               // notify user
-              this._notify("The Item is not available");
+              var msgObj = {
+                type: "error", 
+                duration: 2000, 
+                message: "There Item is not available."
+              };
+              this.fire("socobo-show-toast", msgObj);
             }
           } else {
             // notify user
-            this._notify("The Item is not checked. Please check the Item before delete.");
+            var msgObj2 = {
+              type: "plain", 
+              duration: 2000, 
+              message: "There Item is not checked. Please check the Item before delete."
+            };
+            this.fire("socobo-show-toast", msgObj2);
           }
         },
         /**
@@ -493,7 +514,12 @@ Custom property | Description | Default
             }
           } else {
             // notify user
-            this._notify("The Item is not available");
+            var msgObj = {
+              type: "error", 
+              duration: 2000, 
+              message: "There Item is not available."
+            };
+            this.fire("socobo-show-toast", msgObj);
           }
         },
 
@@ -517,7 +543,12 @@ Custom property | Description | Default
             SocoboGrocery.getInstance(this, this.userLogin).removeItemFromActiveList(e.detail);
           } else {
             // notify user
-            this._notify("The Item is not available");
+            var msgObj = {
+              type: "error", 
+              duration: 2000, 
+              message: "There Item is not available."
+            };
+            this.fire("socobo-show-toast", msgObj);
           }
         },
         /**
@@ -543,7 +574,12 @@ Custom property | Description | Default
               .addItemToActiveList({desc: e.detail.desc});
           } else {
             // notify user
-            this._notify("The Item is not available");
+            var msgObj = {
+              type: "error", 
+              duration: 2000, 
+              message: "There Item is not available."
+            };
+            this.fire("socobo-show-toast", msgObj);
           }
         },
 
@@ -588,20 +624,7 @@ Custom property | Description | Default
           // return selected item index
           return index;
         },
-        /**
-         * Show Toast with specific message
-         *
-         * @param {String} msg
-         * @private
-         * @function
-         */
-        _notify: function(msg) {
-          this.$.infoGroceryList.text = msg;
-          if (!this.$.infoGroceryList.opened) {
-            this.$.infoGroceryList.show();
-          }
-        },
-
+        
         /**
          * LISTENER METHODS
          */
@@ -658,7 +681,12 @@ Custom property | Description | Default
          * @function
          */
         _groceryChangedError: function(error) {
-          this._notify(error.code + " - " + error.message);
+          var msgObj = {
+            type: "error", 
+            duration: 2000, 
+            message: "Grocery List - Error: " + error.code + " - " + error.message
+          };
+          this.fire("socobo-show-toast", msgObj);
         },
 
         /**

--- a/app/elements/socobo-grocery-list/socobo-grocery-list.html
+++ b/app/elements/socobo-grocery-list/socobo-grocery-list.html
@@ -211,13 +211,13 @@ Custom property | Description | Default
         },
         /**
          * unregister tracking changed listeners
-         * 
+         *
          * @function
          */
         unregisterListeners: function() {
           SocoboGrocery.getInstance(this, this.userLogin).unregisterGroceryItemListeners();
         },
-        
+
         /**
          * PRIVATE API
          */
@@ -353,12 +353,11 @@ Custom property | Description | Default
           if (checkItemIndex !== -1) {
             items.splice(checkItemIndex, 1);
           } else {
-            var msgObj = {
-              type: "plain", 
-              duration: 2000, 
+            this._notify({
+              type: "plain",
+              duration: 2000,
               message: "There is no Active Item checked for unchecking."
-            };
-            this.fire("socobo-show-toast", msgObj);
+            });
           }
         },
 
@@ -470,21 +469,19 @@ Custom property | Description | Default
               }
             } else {
               // notify user
-              var msgObj = {
-                type: "error", 
-                duration: 2000, 
+              this._notify({
+                type: "error",
+                duration: 2000,
                 message: "There Item is not available."
-              };
-              this.fire("socobo-show-toast", msgObj);
+              });
             }
           } else {
             // notify user
-            var msgObj2 = {
-              type: "plain", 
-              duration: 2000, 
+            this._notify({
+              type: "plain",
+              duration: 2000,
               message: "There Item is not checked. Please check the Item before delete."
-            };
-            this.fire("socobo-show-toast", msgObj2);
+            });
           }
         },
         /**
@@ -514,12 +511,11 @@ Custom property | Description | Default
             }
           } else {
             // notify user
-            var msgObj = {
-              type: "error", 
-              duration: 2000, 
+            this._notify({
+              type: "error",
+              duration: 2000,
               message: "There Item is not available."
-            };
-            this.fire("socobo-show-toast", msgObj);
+            });
           }
         },
 
@@ -543,12 +539,11 @@ Custom property | Description | Default
             SocoboGrocery.getInstance(this, this.userLogin).removeItemFromActiveList(e.detail);
           } else {
             // notify user
-            var msgObj = {
-              type: "error", 
-              duration: 2000, 
+            this._notify({
+              type: "error",
+              duration: 2000,
               message: "There Item is not available."
-            };
-            this.fire("socobo-show-toast", msgObj);
+            });
           }
         },
         /**
@@ -574,12 +569,11 @@ Custom property | Description | Default
               .addItemToActiveList({desc: e.detail.desc});
           } else {
             // notify user
-            var msgObj = {
-              type: "error", 
-              duration: 2000, 
+            this._notify({
+              type: "error",
+              duration: 2000,
               message: "There Item is not available."
-            };
-            this.fire("socobo-show-toast", msgObj);
+            });
           }
         },
 
@@ -596,8 +590,8 @@ Custom property | Description | Default
          */
         _setHidden: function(item, searchQuery) {
           return !(searchQuery === null ||
-          typeof searchQuery === "undefined" ||
-          item.desc.toUpperCase().match(searchQuery.toUpperCase()));
+            typeof searchQuery === "undefined" ||
+            item.desc.toUpperCase().match(searchQuery.toUpperCase()));
         },
 
         /**
@@ -624,7 +618,7 @@ Custom property | Description | Default
           // return selected item index
           return index;
         },
-        
+
         /**
          * LISTENER METHODS
          */
@@ -681,12 +675,24 @@ Custom property | Description | Default
          * @function
          */
         _groceryChangedError: function(error) {
-          var msgObj = {
-            type: "error", 
-            duration: 2000, 
+          this._notify({
+            type: "error",
+            duration: 2000,
             message: "Grocery List - Error: " + error.code + " - " + error.message
-          };
-          this.fire("socobo-show-toast", msgObj);
+          });
+        },
+
+        /**
+         * Send Notification to inform the User
+         *
+         * @param {Object} options
+         * @function
+         */
+        _notify: function(options) {
+          var type = options && options.type ? options.type : "plain";
+          var dur = options && options.duration ? options.duration : 2000;
+          var msg = options && options.message ? options.message : "Hello, World";
+          this.fire("socobo-show-toast", {type: type, duration: dur, message: msg});
         },
 
         /**

--- a/app/elements/socobo-inventory/socobo-inventory.html
+++ b/app/elements/socobo-inventory/socobo-inventory.html
@@ -186,7 +186,7 @@ Custom property | Description | Default
         },
 
         /**
-         * Listener to handle the create item events. Takes care creating the item and
+         * Listener to handle the create item events. Takes care of creating the item and
          * updating Firebase.
          *
          * @param {Object} e
@@ -260,12 +260,15 @@ Custom property | Description | Default
             var ref = new Firebase(this._handleLogin(this.userLogin) + "/" + item.__firebaseKey__);
             ref.update(item, function(error) {
               if (error) {
-                alert("There was an error updating the item");
+                this.fire("socobo-show-toast",
+                  {type: "error", message: "There was an error updating " + item.name});
                 console.log(error);
               } else {
                 self.$.inventoryEditDialog.hide();
+                this.fire("socobo-show-toast",
+                  {type: "success", message: "Successfully updated " + item.name});
               }
-            });
+            }.bind(this));
           }
         }
       });

--- a/app/elements/socobo-ranking/lib/socobo-ranking.js
+++ b/app/elements/socobo-ranking/lib/socobo-ranking.js
@@ -130,11 +130,26 @@ var SocoboRanking = (function() {
       _refRecipes.on("child_removed", _onCompleteRecipe, _onError, context);
     };
     /**
+     * unregister listener for tracking changes
+     */
+    var unregisterChangedListener = function() {
+      // inventory
+      _refInventory.off("child_added", _onCompleteInventory);
+      _refInventory.off("child_changed", _onCompleteInventory);
+      _refInventory.off("child_removed", _onCompleteInventory);
+      // recipes
+      _refRecipes.off("child_added", _onCompleteRecipe);
+      _refRecipes.off("child_changed", _onCompleteRecipe);
+      _refRecipes.off("child_removed", _onCompleteRecipe);
+    };
+    
+    /**
      * Public API
      */
     return {
       getData: getData,
-      registerChangedListener: registerChangedListener
+      registerChangedListener: registerChangedListener,
+      unregisterChangedListener: unregisterChangedListener
     };
   };
   /**

--- a/app/elements/socobo-ranking/socobo-ranking.html
+++ b/app/elements/socobo-ranking/socobo-ranking.html
@@ -112,8 +112,6 @@ Custom property | Description | Default
         </div>
       </div>
     </div>
-    <!-- Notification-->
-    <paper-toast id="infoRanking" duration="2000"></paper-toast>
   </template>
 
   <script>
@@ -167,17 +165,35 @@ Custom property | Description | Default
           SocoboRanking.getInstance(this.userLogin)
             .getData()
             .then(function(data) {
-              this._notify("Loading Data finished! Calculating started...");
+              var msgObj = {
+                type: "plain", 
+                duration: 2000, 
+                message: "Loading Data finished! Calculating started..."
+              };
+              this.fire("socobo-show-toast", msgObj);
               this._calcRanking(data);
             }.bind(this))
             .catch(function(error) {
-              this._notify(error.message);
+              var msgObj = {
+                type: "error", 
+                duration: 2000, 
+                message: "ERROR: " + error.message
+              };
+              this.fire("socobo-show-toast", msgObj);
             }.bind(this));
           // register changed listener
           if (this.isFirstLoad) {
             SocoboRanking.getInstance(this.userLogin).registerChangedListener(this);
             this.isFirstLoad = false;
           }
+        },
+        /**
+         * unregister tracking changed listeners
+         * 
+         * @function
+         */
+        unregisterListeners: function() {
+          SocoboRanking.getInstance(this.userLogin).unregisterChangedListener();
         },
 
         /**
@@ -190,12 +206,22 @@ Custom property | Description | Default
         _calcRanking: function(data) {
           // check Data
           if (data === null || typeof(data) === "undefined") {
-            this._notify("No Data for Ranking available!");
+            var msgObj = {
+              type: "error", 
+              duration: 2000, 
+              message: "Ranking - Error - No Data for Ranking available!"
+            };
+            this.fire("socobo-show-toast", msgObj);
             return false;
           }
           // check Data length
           if (data.length !== 2) {
-            this._notify("Error - One needed Item is missing!");
+            var msgObj2 = {
+              type: "error", 
+              duration: 2000, 
+              message: "Ranking - Error - One needed Item is missing!" 
+            };
+            this.fire("socobo-show-toast", msgObj2);
             return false;
           }
           //extract data
@@ -245,7 +271,12 @@ Custom property | Description | Default
           // sort desc
           this._sortList(true);
           // notify user
-          this._notify("Calculating finished!");
+          var msgObj3 = {
+            type: "plain", 
+            duration: 2000, 
+            message: "Calculating finished!" 
+          };
+          this.fire("socobo-show-toast", msgObj3);
           // reset loading flag
           this.isLoading = false;
         },
@@ -524,7 +555,12 @@ Custom property | Description | Default
          */
         _reload: function() {
           // notify user
-          this._notify("Reloading...");
+          var msgObj = {
+            type: "plain", 
+            duration: 2000, 
+            message: "Reloading..." 
+          };
+          this.fire("socobo-show-toast", msgObj);
           // reset recipe ranking
           this.set("recipeRanking", []);
           // reload data
@@ -594,20 +630,6 @@ Custom property | Description | Default
         },
 
         /**
-         * Show Toast with specific message
-         *
-         * @param {String} msg
-         * @private
-         * @function
-         */
-        _notify: function(msg) {
-          this.$.infoRanking.text = msg;
-          if (!this.$.infoRanking.opened) {
-            this.$.infoRanking.show();
-          }
-        },
-
-        /**
          * tracking changes in inventory items
          *
          * @private
@@ -639,7 +661,12 @@ Custom property | Description | Default
          * @function
          */
         _onChangedError: function(e) {
-          this._notify("Ranking - Reloading Error: " + e.detail.message);
+          var msgObj = {
+            type: "error", 
+            duration: 2000, 
+            message: "Ranking - Reloading Error: " + e.detail.message 
+          };
+          this.fire("socobo-show-toast", msgObj);
         },
 
         /**

--- a/app/elements/socobo-ranking/socobo-ranking.html
+++ b/app/elements/socobo-ranking/socobo-ranking.html
@@ -165,21 +165,19 @@ Custom property | Description | Default
           SocoboRanking.getInstance(this.userLogin)
             .getData()
             .then(function(data) {
-              var msgObj = {
-                type: "plain", 
-                duration: 2000, 
+              this._notify({
+                type: "plain",
+                duration: 2000,
                 message: "Loading Data finished! Calculating started..."
-              };
-              this.fire("socobo-show-toast", msgObj);
+              });
               this._calcRanking(data);
             }.bind(this))
             .catch(function(error) {
-              var msgObj = {
-                type: "error", 
-                duration: 2000, 
-                message: "ERROR: " + error.message
-              };
-              this.fire("socobo-show-toast", msgObj);
+              this._notify({
+                type: "error",
+                duration: 2000,
+                message: "Ranking - Error - " + error.message
+              });
             }.bind(this));
           // register changed listener
           if (this.isFirstLoad) {
@@ -189,7 +187,7 @@ Custom property | Description | Default
         },
         /**
          * unregister tracking changed listeners
-         * 
+         *
          * @function
          */
         unregisterListeners: function() {
@@ -206,22 +204,20 @@ Custom property | Description | Default
         _calcRanking: function(data) {
           // check Data
           if (data === null || typeof(data) === "undefined") {
-            var msgObj = {
-              type: "error", 
-              duration: 2000, 
+            this._notify({
+              type: "error",
+              duration: 2000,
               message: "Ranking - Error - No Data for Ranking available!"
-            };
-            this.fire("socobo-show-toast", msgObj);
+            });
             return false;
           }
           // check Data length
           if (data.length !== 2) {
-            var msgObj2 = {
-              type: "error", 
-              duration: 2000, 
-              message: "Ranking - Error - One needed Item is missing!" 
-            };
-            this.fire("socobo-show-toast", msgObj2);
+            this._notify({
+              type: "error",
+              duration: 2000,
+              message: "Ranking - Error - One needed Item is missing!"
+            });
             return false;
           }
           //extract data
@@ -271,12 +267,11 @@ Custom property | Description | Default
           // sort desc
           this._sortList(true);
           // notify user
-          var msgObj3 = {
-            type: "plain", 
-            duration: 2000, 
-            message: "Calculating finished!" 
-          };
-          this.fire("socobo-show-toast", msgObj3);
+          this._notify({
+            type: "plain",
+            duration: 2000,
+            message: "Calculating finished!"
+          });
           // reset loading flag
           this.isLoading = false;
         },
@@ -555,12 +550,11 @@ Custom property | Description | Default
          */
         _reload: function() {
           // notify user
-          var msgObj = {
-            type: "plain", 
-            duration: 2000, 
-            message: "Reloading..." 
-          };
-          this.fire("socobo-show-toast", msgObj);
+          this._notify({
+            type: "plain",
+            duration: 2000,
+            message: "Reloading..."
+          });
           // reset recipe ranking
           this.set("recipeRanking", []);
           // reload data
@@ -661,12 +655,24 @@ Custom property | Description | Default
          * @function
          */
         _onChangedError: function(e) {
-          var msgObj = {
-            type: "error", 
-            duration: 2000, 
-            message: "Ranking - Reloading Error: " + e.detail.message 
-          };
-          this.fire("socobo-show-toast", msgObj);
+          this._notify({
+            type: "error",
+            duration: 2000,
+            message: "Ranking - Reloading Error: " + e.detail.message
+          });
+        },
+
+        /**
+         * Send Notification to inform the User
+         *
+         * @param {Object} options
+         * @function
+         */
+        _notify: function(options) {
+          var type = options && options.type ? options.type : "plain";
+          var dur = options && options.duration ? options.duration : 2000;
+          var msg = options && options.message ? options.message : "Hello, World";
+          this.fire("socobo-show-toast", {type: type, duration: dur, message: msg});
         },
 
         /**

--- a/app/elements/socobo-ranking/socobo-ranking.html
+++ b/app/elements/socobo-ranking/socobo-ranking.html
@@ -166,8 +166,6 @@ Custom property | Description | Default
             .getData()
             .then(function(data) {
               this._notify({
-                type: "plain",
-                duration: 2000,
                 message: "Loading Data finished! Calculating started..."
               });
               this._calcRanking(data);
@@ -175,7 +173,6 @@ Custom property | Description | Default
             .catch(function(error) {
               this._notify({
                 type: "error",
-                duration: 2000,
                 message: "Ranking - Error - " + error.message
               });
             }.bind(this));
@@ -206,7 +203,6 @@ Custom property | Description | Default
           if (data === null || typeof(data) === "undefined") {
             this._notify({
               type: "error",
-              duration: 2000,
               message: "Ranking - Error - No Data for Ranking available!"
             });
             return false;
@@ -215,7 +211,6 @@ Custom property | Description | Default
           if (data.length !== 2) {
             this._notify({
               type: "error",
-              duration: 2000,
               message: "Ranking - Error - One needed Item is missing!"
             });
             return false;
@@ -268,8 +263,6 @@ Custom property | Description | Default
           this._sortList(true);
           // notify user
           this._notify({
-            type: "plain",
-            duration: 2000,
             message: "Calculating finished!"
           });
           // reset loading flag
@@ -551,8 +544,6 @@ Custom property | Description | Default
         _reload: function() {
           // notify user
           this._notify({
-            type: "plain",
-            duration: 2000,
             message: "Reloading..."
           });
           // reset recipe ranking
@@ -657,7 +648,6 @@ Custom property | Description | Default
         _onChangedError: function(e) {
           this._notify({
             type: "error",
-            duration: 2000,
             message: "Ranking - Reloading Error: " + e.detail.message
           });
         },

--- a/app/elements/socobo-recipe/socobo-recipe-details-add.html
+++ b/app/elements/socobo-recipe/socobo-recipe-details-add.html
@@ -510,8 +510,8 @@ Custom property | Description | Default
             } else {
               this.recipe.image = this.image.getImageAsString();
             }
-            this.fire("add_request", this.recipe);
             this._clearInputFields();
+            this.fire("add_request", this.recipe);
             this.$.dialog.close();
           } else {
             this.fire("socobo-show-toast", {type: "error", message: validationResult.message});

--- a/app/elements/socobo-recipe/socobo-recipe-details-add.html
+++ b/app/elements/socobo-recipe/socobo-recipe-details-add.html
@@ -514,19 +514,8 @@ Custom property | Description | Default
             this._clearInputFields();
             this.$.dialog.close();
           } else {
-            this._notify(validationResult.message);
+            this.fire("socobo-show-toast", {type: "error", message: validationResult.message});
           }
-        },
-        /**
-         * Shows a given message as paper-toast element
-         *
-         * @param {String} msg
-         * @private
-         * @function
-         */
-        _notify: function(msg) {
-          this.$.errorNotification.text = msg;
-          this.$.errorNotification.show();
         }
       });
     })();

--- a/app/elements/socobo-recipe/socobo-recipe-details-add.html
+++ b/app/elements/socobo-recipe/socobo-recipe-details-add.html
@@ -510,8 +510,8 @@ Custom property | Description | Default
             } else {
               this.recipe.image = this.image.getImageAsString();
             }
-            this._clearInputFields();
             this.fire("add_request", this.recipe);
+            this._clearInputFields();
             this.$.dialog.close();
           } else {
             this.fire("socobo-show-toast", {type: "error", message: validationResult.message});

--- a/app/elements/socobo-recipe/socobo-recipe-details-edit.html
+++ b/app/elements/socobo-recipe/socobo-recipe-details-edit.html
@@ -578,18 +578,9 @@ Custom property | Description | Default
             this._clearInputFields();
             this.$.dialog.close();
           } else {
-            this._notify(validationResult.message);
+            this.fire("socobo-show-toast", {type: "error", message: validationResult.message});
+
           }
-        },
-        /**
-         * Shows a given message as paper-toast element
-         *
-         * @param {String} msg
-         * @private
-         */
-        _notify: function(msg) {
-          this.$.errorNotification.text = msg;
-          this.$.errorNotification.show();
         }
       });
     })();

--- a/app/elements/socobo-recipe/socobo-recipe-overview.html
+++ b/app/elements/socobo-recipe/socobo-recipe-overview.html
@@ -69,7 +69,7 @@ Custom property | Description | Default
         --paper-spinner-layer-4-color: var(--socobo-recipe-style-spinner-color-level4);
       }
 
-      .loadspinner {
+      .loadingSpinner {
         --paper-spinner-layer-1-color: var(--socobo-recipe-style-spinner-color-level1);
         --paper-spinner-layer-2-color: var(--socobo-recipe-style-spinner-color-level2);
         --paper-spinner-layer-3-color: var(--socobo-recipe-style-spinner-color-level3);
@@ -83,25 +83,39 @@ Custom property | Description | Default
       }
 
       /* NOTIFICATION */
-      .error-note{
-        --paper-toast-background-color: var(--socobo-recipe-style-error-notification-color);
-        --paper-toast-color: var(--socobo-recipe-style-notification-text-color);
-      }
-      .success-note{
-        --paper-toast-background-color: var(--socobo-recipe-style-success-notification-color);
-        --paper-toast-color: var(--socobo-recipe-style-notification-text-color);
-      }
-      .load-note{
-        --paper-toast-background-color: var(--socobo-recipe-style-loading-notification-color);
-        --paper-toast-color: var(--socobo-recipe-style-notification-text-color);
+      .loadingInfo{
         @apply(--layout-horizontal);
         @apply(--layout-center);
-        padding-top: 0;
-        padding-bottom: 0;
+      }
+      .loadingWrapper {
+        display: none;
+        position: fixed;
+        left: 50%;
+        margin-left: -90px;
+        width: 180px;
+        height: 30px;
+        top: 42px;
+        background-color: var(--socobo-recipe-style-notification-text-color);
+        padding: 5px;
+        border-radius: 20px;
       }
 
-    </style>
+      .loadingSpinner {
+        margin-right: 15px;
+      }
 
+
+    </style>
+    <paper-material elevation="2" id="loadingWrapper" class="loadingWrapper">
+      <div id="loadingInfo" class="loadingInfo">
+        <div>
+          <paper-spinner active id="loadingSpinner" class="loadingSpinner"></paper-spinner>
+        </div>
+        <div>
+          <span id="loadingText" class="loadingText"></span>
+        </div>
+      </div>
+    </paper-material>
     <!-- Show Dialog -->
     <socobo-recipe-details-show
       id="showDialog">
@@ -159,16 +173,6 @@ Custom property | Description | Default
       on-delete-items="_removeAllChecked"
       show-delete="{{_showDelete}}">
     </socobo-element-buttons>
-
-    <!-- Notification -->
-    <paper-toast id="loadNotification" class="load-note" duration="-1">
-      <div>
-        <paper-spinner id="loadspinner" class="loadspinner" active></paper-spinner>
-      </div>
-      <div>
-        <paper-item id="loadtext"></paper-item>
-      </div>
-    </paper-toast>
   </template>
 
   <script>
@@ -351,14 +355,16 @@ Custom property | Description | Default
          * @private
          */
         _removeRecipe: function(e) {
-          this._notifyOnLoading("Deleting recipe");
+          this._toggleLoadingNotification("Removing Recipe");
           RecipeDao.getInstance(this.userLogin)
             .remove(e.detail)
             .then(function(success) {
+              this._toggleLoadingNotification();
               this._notifyOnSuccess(success.value);
               this._updateAfterDeletion(e.detail, this.recipes, "recipes");
             }.bind(this))
             .catch(function(error) {
+              this._toggleLoadingNotification();
               this._notifyOnError(error.value);
             }.bind(this));
         },
@@ -370,12 +376,12 @@ Custom property | Description | Default
          * @private
          */
         _addNewRecipe: function(e) {
-          // this._notifyOnLoading("Adding recipe");
+          this._toggleLoadingNotification("Adding Recipe");
           RecipeDao.getInstance(this.userLogin)
             .add(e.detail)
             .then(function(success) {
+              this._toggleLoadingNotification();
               this._notifyOnSuccess(success.value);
-
               RecipeDao.getInstance(this.userLogin)
                 .getAll()
                 .then(function(recipes) {
@@ -383,6 +389,7 @@ Custom property | Description | Default
                   this.set("recipes", recipes.value);
                 }.bind(this))
                 .catch(function(error) {
+                  this._toggleLoadingNotification();
                   this._notifyOnError(error.value);
                 }.bind(this));
 
@@ -400,10 +407,11 @@ Custom property | Description | Default
          * @private
          */
         _editRecipe: function(e) {
-          this._notifyOnLoading("Updating recipe");
+          this._toggleLoadingNotification("Updating Recipe");
           RecipeDao.getInstance(this.userLogin)
             .update(e.detail)
             .then(function(success) {
+              this._toggleLoadingNotification();
               this._notifyOnSuccess(success.value);
 
               RecipeDao.getInstance(this.userLogin)
@@ -413,6 +421,7 @@ Custom property | Description | Default
                   this.set("recipes", recipes.value);
                 }.bind(this))
                 .catch(function(error) {
+                  this._toggleLoadingNotification();
                   this._notifyOnError(error.value);
                 }.bind(this));
 
@@ -501,8 +510,11 @@ Custom property | Description | Default
          * @private
          * @function
          */
-        _notifyOnLoading: function(msg) {
-          this.fire("socobo-show-toast", {type: "spinner", message: msg, duration: Infinity});
+        _toggleLoadingNotification: function(msg) {
+          var wrapper;
+          this.$.loadingText.innerHTML = msg;
+          wrapper = this.$.loadingWrapper;
+          wrapper.style.display === "block" ? wrapper.style.display = "none" : wrapper.style.display = "block";
         },
         /**
          * Enables all checkboxes on checking the main checkbox of the search bar

--- a/app/elements/socobo-recipe/socobo-recipe-overview.html
+++ b/app/elements/socobo-recipe/socobo-recipe-overview.html
@@ -504,17 +504,17 @@ Custom property | Description | Default
           this.fire("socobo-show-toast", {type: "success", message: msg});
         },
         /**
-         * Shows a given loading message as paper-toast element
+         * Shows a given loading message as paper-material notification at the top
          *
          * @param {String} msg
          * @private
          * @function
          */
         _toggleLoadingNotification: function(msg) {
-          var wrapper;
+          var wrapperStyle;
           this.$.loadingText.innerHTML = msg;
-          wrapper = this.$.loadingWrapper;
-          wrapper.style.display === "block" ? wrapper.style.display = "none" : wrapper.style.display = "block";
+          wrapperStyle = this.$.loadingWrapper.style;
+          wrapperStyle.display = (wrapperStyle.display === "block") ? "none" : "block";
         },
         /**
          * Enables all checkboxes on checking the main checkbox of the search bar

--- a/app/elements/socobo-recipe/socobo-recipe-overview.html
+++ b/app/elements/socobo-recipe/socobo-recipe-overview.html
@@ -161,8 +161,6 @@ Custom property | Description | Default
     </socobo-element-buttons>
 
     <!-- Notification -->
-    <paper-toast id="errorNotification" class="error-note"></paper-toast>
-    <paper-toast id="successNotification" class="success-note"></paper-toast>
     <paper-toast id="loadNotification" class="load-note" duration="-1">
       <div>
         <paper-spinner id="loadspinner" class="loadspinner" active></paper-spinner>
@@ -372,7 +370,7 @@ Custom property | Description | Default
          * @private
          */
         _addNewRecipe: function(e) {
-          this._notifyOnLoading("Adding recipe");
+          // this._notifyOnLoading("Adding recipe");
           RecipeDao.getInstance(this.userLogin)
             .add(e.detail)
             .then(function(success) {
@@ -484,8 +482,7 @@ Custom property | Description | Default
          * @function
          */
         _notifyOnError: function(msg) {
-          this.$.errorNotification.text = msg;
-          this.$.errorNotification.show();
+          this.fire("socobo-show-toast", {type: "error", message: msg});
         },
         /**
          * Shows a given success message as paper-toast element
@@ -495,8 +492,7 @@ Custom property | Description | Default
          * @function
          */
         _notifyOnSuccess: function(msg) {
-          this.$.successNotification.text = msg;
-          this.$.successNotification.show();
+          this.fire("socobo-show-toast", {type: "success", message: msg});
         },
         /**
          * Shows a given loading message as paper-toast element
@@ -506,8 +502,7 @@ Custom property | Description | Default
          * @function
          */
         _notifyOnLoading: function(msg) {
-          this.$.loadtext.innerHTML = msg;
-          this.$.loadNotification.opened = true;
+          this.fire("socobo-show-toast", {type: "spinner", message: msg, duration: Infinity});
         },
         /**
          * Enables all checkboxes on checking the main checkbox of the search bar

--- a/app/index.html
+++ b/app/index.html
@@ -187,6 +187,7 @@
       </paper-header-panel>
     </paper-drawer-panel>
 
+    <socobo-element-toast></socobo-element-toast>
     <paper-toast
       id="info-toast"
       duration="6000"

--- a/app/index.html
+++ b/app/index.html
@@ -187,12 +187,8 @@
       </paper-header-panel>
     </paper-drawer-panel>
 
+    <!-- Socobo Toast Element -->
     <socobo-element-toast></socobo-element-toast>
-    <paper-toast
-      id="info-toast"
-      duration="6000"
-      text="Placeholder">
-    </paper-toast>
 
     <!-- Service Worker support -->
     <paper-toast
@@ -216,7 +212,7 @@
   </template>
 
   <!--firebase-->
-  <script src="https://cdn.firebase.com/js/client/2.3.2/firebase.js"></script>
+  <script src="https://cdn.firebase.com/js/client/2.4.1/firebase.js"></script>
   <!-- build:js scripts/app.js -->
   <script src="scripts/app.js"></script>
   <!-- endbuild-->

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -133,21 +133,19 @@
     // get error object
     var errorObj = e.detail.error;
     // show toast to inform the user
-    var msgObj = {
-      type: "error", 
-      duration: 2000, 
-      message: "Login failed! Please retry! Error Code: " + errorObj.code + ", Error: " + errorObj.message 
-    };
-    this.fire("socobo-show-toast", msgObj);
+    Util.notify(this, {
+      type: "error",
+      duration: 2000,
+      message: "Login failed! Please retry! Error Code: " + errorObj.code + ", Error: " + errorObj.message
+    });
   };
   app.passwordsMisMatching = function() {
     // show toast to inform the user
-    var msgObj = {
-      type: "error", 
-      duration: 2000, 
-      message: "Your Passwords does not match! Please retry!" 
-    };
-    this.fire("socobo-show-toast", msgObj);
+    Util.notify(this, {
+      type: "error",
+      duration: 2000,
+      message: "Your Passwords does not match! Please retry!"
+    });
   };
   /**
    * RANKING
@@ -175,12 +173,11 @@
     UserInfo.set(UserInfo.EMAILADDRESS, e.detail.email);
     UserInfo.set(UserInfo.PROFILEIMAGE, e.detail.profileImage);
     // show toast to inform the user
-    var msgObj = {
-      type: "success", 
-      duration: 2000, 
-      message: "User " + e.detail.email + " is logged in!" 
-    };
-    this.fire("socobo-show-toast", msgObj);
+    Util.notify(this, {
+      type: "success",
+      duration: 2000,
+      message: "User " + e.detail.email + " is logged in!"
+    });
   };
   app.handleProfileImageChanged = function(e) {
     // set UserInfo to Menubar
@@ -207,12 +204,11 @@
       infoText = "Logging out...";
     }
     // show toast to inform the user
-    var msgObj = {
-      type: "plain", 
-      duration: 2000, 
-      message: infoText 
-    };
-    this.fire("socobo-show-toast", msgObj);
+    Util.notify(this, {
+      type: "plain",
+      duration: 2000,
+      message: infoText
+    });
     // unregister tracking listeners
     elRanking.unregisterListeners();
     elGroceryList.unregisterListeners();

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -28,8 +28,6 @@
   var elRecipe = null;
   var elProfile = null;
   var elAbout = null;
-  // Other
-  var infoToast = null;
 
   /**
    * global eventlistener
@@ -63,8 +61,6 @@
     elRecipe = document.querySelector("#elRecipe");
     elProfile = document.querySelector("#elProfile");
     elAbout = document.querySelector("#elAbout");
-    // Other
-    infoToast = document.querySelector("#info-toast");
     // init UserInfo
     UserInfo.init("https://socobo-dev-project.firebaseio.com/");
     // set FirebaseUrl, UserId and ExpireDate for Subelements
@@ -137,16 +133,21 @@
     // get error object
     var errorObj = e.detail.error;
     // show toast to inform the user
-    Util.showToast(
-      infoToast,
-      "Login failed! Please retry! Error Code: " + errorObj.code + ", Error: " + errorObj.message,
-      "#FF3333",
-      "#EEEEEE"
-    );
+    var msgObj = {
+      type: "error", 
+      duration: 2000, 
+      message: "Login failed! Please retry! Error Code: " + errorObj.code + ", Error: " + errorObj.message 
+    };
+    this.fire("socobo-show-toast", msgObj);
   };
   app.passwordsMisMatching = function() {
     // show toast to inform the user
-    Util.showToast(infoToast, "Your Passwords does not match! Please retry!", "#FF3333", "#EEEEEE");
+    var msgObj = {
+      type: "error", 
+      duration: 2000, 
+      message: "Your Passwords does not match! Please retry!" 
+    };
+    this.fire("socobo-show-toast", msgObj);
   };
   /**
    * RANKING
@@ -174,7 +175,12 @@
     UserInfo.set(UserInfo.EMAILADDRESS, e.detail.email);
     UserInfo.set(UserInfo.PROFILEIMAGE, e.detail.profileImage);
     // show toast to inform the user
-    Util.showToast(infoToast, "User " + e.detail.email + " is logged in!", "#2EB82E", "#EEEEEE");
+    var msgObj = {
+      type: "success", 
+      duration: 2000, 
+      message: "User " + e.detail.email + " is logged in!" 
+    };
+    this.fire("socobo-show-toast", msgObj);
   };
   app.handleProfileImageChanged = function(e) {
     // set UserInfo to Menubar
@@ -201,7 +207,15 @@
       infoText = "Logging out...";
     }
     // show toast to inform the user
-    Util.showToast(infoToast, infoText, "#333333", "#EEEEEE");
+    var msgObj = {
+      type: "plain", 
+      duration: 2000, 
+      message: infoText 
+    };
+    this.fire("socobo-show-toast", msgObj);
+    // unregister tracking listeners
+    elRanking.unregisterListeners();
+    elGroceryList.unregisterListeners();
     // log user out from firebase
     var rootRef = new Firebase(UserInfo.getBaseUrl());
     rootRef.unauth();

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -135,7 +135,6 @@
     // show toast to inform the user
     Util.notify(this, {
       type: "error",
-      duration: 2000,
       message: "Login failed! Please retry! Error Code: " + errorObj.code + ", Error: " + errorObj.message
     });
   };
@@ -143,7 +142,6 @@
     // show toast to inform the user
     Util.notify(this, {
       type: "error",
-      duration: 2000,
       message: "Your Passwords does not match! Please retry!"
     });
   };
@@ -175,7 +173,6 @@
     // show toast to inform the user
     Util.notify(this, {
       type: "success",
-      duration: 2000,
       message: "User " + e.detail.email + " is logged in!"
     });
   };
@@ -205,8 +202,6 @@
     }
     // show toast to inform the user
     Util.notify(this, {
-      type: "plain",
-      duration: 2000,
       message: infoText
     });
     // unregister tracking listeners

--- a/app/scripts/util.js
+++ b/app/scripts/util.js
@@ -61,7 +61,19 @@ var Util = (function() {
       _toggleMI(menuItem);
     });
   };
-  
+  /**
+   * Send Notification to inform the User
+   *
+   * @param {Object} ctx
+   * @param {Object} options
+   */
+  var notify = function(ctx, options) {
+    var type = options && options.type ? options.type : "plain";
+    var dur = options && options.duration ? options.duration : 2000;
+    var msg = options && options.message ? options.message : "Hello, World";
+    ctx.fire("socobo-show-toast", {type: type, duration: dur, message: msg});
+  };
+
   /**
    * make functions public
    */
@@ -69,6 +81,7 @@ var Util = (function() {
     objectToString: objectToString,
     stringToObject: stringToObject,
     isUserLoginExpired: isUserLoginExpired,
-    toggleMenuItems: toggleMenuItems
+    toggleMenuItems: toggleMenuItems,
+    notify: notify
   };
 })();

--- a/app/scripts/util.js
+++ b/app/scripts/util.js
@@ -61,21 +61,7 @@ var Util = (function() {
       _toggleMI(menuItem);
     });
   };
-  /**
-   * show info toast
-   *
-   * @param {HTMLElement} toast
-   * @param {String} text
-   * @param {String} bgColor
-   * @param {String} color
-   */
-  var showToast = function(toast, text, bgColor, color) {
-    toast.text = text;
-    toast.style.background = bgColor;
-    toast.style.color = color;
-    toast.show();
-  };
-
+  
   /**
    * make functions public
    */
@@ -83,7 +69,6 @@ var Util = (function() {
     objectToString: objectToString,
     stringToObject: stringToObject,
     isUserLoginExpired: isUserLoginExpired,
-    toggleMenuItems: toggleMenuItems,
-    showToast: showToast
+    toggleMenuItems: toggleMenuItems
   };
 })();

--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -27,10 +27,6 @@
     --divider-color:              #B6B6B6;
     --bg-focus-color:             #E0E0E0;
     --border-color:               #000000;
-    --socobo-toast-style-success-notification-color: lime;
-    --socobo-toast-style-error-notification-color: red;
-    --socobo-toast-style-plain-notification-color: grey;
-    --socobo-toast-style-spinner-notification-color: grey;
 
     /* Components */
     /* paper-drawer-panel */
@@ -178,6 +174,13 @@
 
   /*Custom Socobo Elements*/
   /*Use Custom CSS Mixins*/
+  socobo-element-toast {
+    --socobo-toast-style-success-notification-color: lime;
+    --socobo-toast-style-error-notification-color: red;
+    --socobo-toast-style-plain-notification-color: grey;
+    --socobo-toast-style-spinner-notification-color: grey;
+  }
+
   socobo-auth {
     --socobo-auth-bg-image-theme: {
        top: 67px;

--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -27,6 +27,10 @@
     --divider-color:              #B6B6B6;
     --bg-focus-color:             #E0E0E0;
     --border-color:               #000000;
+    --socobo-toast-style-success-notification-color: lime;
+    --socobo-toast-style-error-notification-color: red;
+    --socobo-toast-style-plain-notification-color: grey;
+    --socobo-toast-style-spinner-notification-color: grey;
 
     /* Components */
     /* paper-drawer-panel */
@@ -205,8 +209,6 @@
     --socobo-inventory-create-style-input-only-color-color: var(--secondary-text-color);
     --socobo-inventory-create-style-input-only-color-focus-color: var(--dark-primary-color);
     --socobo-inventory-create-style-input-only-color-input-color: var(--primary-text-color);
-    --socobo-style-action-btn-add-color: var(--accent-color);
-    --socobo-style-action-btn-delete-color: red;
   }
 
   socobo-recipe {

--- a/app/test/index.html
+++ b/app/test/index.html
@@ -35,7 +35,9 @@
         "socobo-grocery-list/socobo-grocery-list.html",
 
         "socobo-about/socobo-about.html",
-        "socobo-about/socobo-about-github-card.html"
+        "socobo-about/socobo-about-github-card.html",
+
+        "socobo-element-toast/socobo-element-toast.html"
       ]);
     </script>
   </body>

--- a/app/test/socobo-element-toast/socobo-element-toast.html
+++ b/app/test/socobo-element-toast/socobo-element-toast.html
@@ -81,7 +81,7 @@
         var msgInfinity = {type: "success", message: "foo", duration: Infinity};
 
         expect(toast._extractDuration(msg)).to.be.eql(9000);
-        expect(toast._extractDuration(msgInfinity)).to.be.eql(Infinity);
+        expect(toast._extractDuration(msgInfinity)).to.be.eql(3000);
         done();
       });
 

--- a/app/test/socobo-element-toast/socobo-element-toast.html
+++ b/app/test/socobo-element-toast/socobo-element-toast.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>socobo-element-list-item basic tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
+  <script src="../../bower_components/iron-test-helpers/mock-interactions.js"></script>
+
+  <link rel="import" href="../../elements/elements.html">
+</head>
+<body>
+
+  <test-fixture id="Toast">
+    <template>
+      <socobo-element-toast></socobo-element-toast>
+    </template>
+  </test-fixture>
+
+  <script>
+    suite("<socobo-element-toast>", function() {
+      var toast;
+
+      setup(function() {
+        toast = fixture('Toast');
+      });
+
+      test("exists", function(done) {
+        expect(toast).to.not.be.eql(undefined);
+        done();
+      });
+
+      test("hast a paper-toast", function(done) {
+        expect(toast.querySelector('paper-toast')).to.not.be.eql(undefined);
+        done();
+      });
+
+      test("firing socobo-show-toast event opens toast", function(done) {
+        var msg = {type: "success", message: "foo"};
+        toast.fire("socobo-show-toast", msg);
+        flush(function() {
+          expect(toast.querySelector('paper-toast').opened).to.be.eql(true);
+          done();
+        });
+      });
+
+      test("firing two socobo-show-toast events consecutively still only opens one toast", function(done) {
+        var msg = {type: "success", message: "foo"};
+        toast.fire("socobo-show-toast", msg);
+        toast.fire("socobo-show-toast", msg);
+
+        flush(function() {
+          expect(toast.querySelectorAll('paper-toast').length).to.be.eql(1);
+          done();
+        });
+      });
+
+      test("after duration passed no toast is displayed", function(done) {
+        var msg = {type: "success", message: "foo"};
+        toast.fire("socobo-show-toast", msg);
+
+        flush(function() {
+          toast.async(function() {
+            expect(toast.querySelector('paper-toast').opened).to.be.eql(false, "Toast should not be opened");
+            done();
+          }, 5000);
+        });
+      });
+
+      test("_extractDuration defaults to 3000 if no duration is set", function(done) {
+        var msg = {type: "success", message: "foo"};
+        expect(toast._extractDuration(msg)).to.be.eql(3000);
+        done();
+      });
+
+      test("_extractDuration returns duration set in the input", function(done) {
+        var msg = {type: "success", message: "foo", duration: 9000};
+        var msgInfinity = {type: "success", message: "foo", duration: Infinity};
+
+        expect(toast._extractDuration(msg)).to.be.eql(9000);
+        expect(toast._extractDuration(msgInfinity)).to.be.eql(Infinity);
+        done();
+      });
+
+      test("_extractDuration normalizes negative/0 values to default of 3000", function(done) {
+        var msg = {type: "success", message: "foo", duration: -1};
+        var msgZero = {type: "success", message: "foo", duration: 0};
+
+        expect(toast._extractDuration(msgZero)).to.be.eql(3000);
+        done();
+      });
+    });
+  </script>
+</body>
+</html>

--- a/app/test/socobo-recipe/socobo-recipe-details-add.html
+++ b/app/test/socobo-recipe/socobo-recipe-details-add.html
@@ -216,7 +216,7 @@
           });
         });
 
-        test('createNewRecipe fires socobo-show-toast event if reciep is invalid', function() {
+        test('createNewRecipe fires socobo-show-toast event if reciep is invalid', function(done) {
           socoboRecipeDetailsAdd.addEventListener("socobo-show-toast", function(){
             done();
           });

--- a/app/test/socobo-recipe/socobo-recipe-details-add.html
+++ b/app/test/socobo-recipe/socobo-recipe-details-add.html
@@ -75,7 +75,7 @@
 
         teardown(function(){
           mock_add.restore();
-        })
+        });
 
         test("Add step on clicking the add step button", function(){
           var btn_add_stp = socoboRecipeDetailsAdd.$.addStep;
@@ -203,7 +203,6 @@
         });
 
         test('createNewRecipe fires no add_request event if the recipe is invalid', function (done) {
-          mock_add.expects("_notify").once();
           socoboRecipeDetailsAdd.addEventListener("add_request", function(){
             throw new Error("Should not catch an event");
           });
@@ -217,30 +216,27 @@
           });
         });
 
-        test('createNewRecipe creates a recipe correctly', function (done) {
-          mock_add.expects("_clearInputFields").once();
-          var steps = [{number: 0, desc: "testStep"}];
-          var ingredients = [{desc : "test_ingr", amount: 12, unit: "kg"}];
-          var title = "test_title";
-          var text = "test_text";
-          socoboRecipeDetailsAdd.image = new ImageService();
-          sinon.stub(socoboRecipeDetailsAdd.image, "getImageAsString", function(){
-            return "test_image";
-          });
-          socoboRecipeDetailsAdd.addEventListener("add_request", function(){
+        test('createNewRecipe fires socobo-show-toast event if reciep is invalid', function() {
+          socoboRecipeDetailsAdd.addEventListener("socobo-show-toast", function(){
             done();
           });
           sinon.stub(socoboRecipeDetailsAdd, "validate", function(){
-            return {isValid: true, message: "Test"};
+            return {isValid: false, message: "Test"};
           });
           flush(function () {
             socoboRecipeDetailsAdd.createNewRecipe();
-            mock_add.verify();
           });
         });
 
-        //TODO: test encode method
+        test('createNewRecipe calls clearInputField if recipe is valid', function () {
+          mock_add.expects("_clearInputFields");
 
+          sinon.stub(socoboRecipeDetailsAdd, "validate", function(){
+            return {isValid: true, message: "Test"};
+          });
+          socoboRecipeDetailsAdd.createNewRecipe();
+          mock_add.verify();
+        });
       });
 
 


### PR DESCRIPTION
Add new element
Implement demo to showcase success, error, plain and spinner toasts
Add the toast element to index.html
Call the toast from socobo-inventory on inventory item update (both success and error case)

Work in progress, this is for @flashback2k14 and @hetec to get an overview and make API suggestions.

The spinner toast is not yet implemented. I thought of using a cancellationToken in the message when firing a `socobo-toast-start` event that can be cancelled using the same Token in a `socobo-toast-stop` event.
