### PR TITLE
ba-177 Fix Firebase Deploy 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - node_modules
     - app/bower_components
 before_script:
-  - npm install web-component-tester firebase-tools firebase-bolt
+  - npm install web-component-tester firebase-tools@2.2.1 firebase-bolt
   - npm install bower
   - 'export PATH=$PWD/node_modules/.bin:$PATH'
   - bower install


### PR DESCRIPTION
ba-177 Fix Firebase Deploy 

Peg `firebase-tools` version to 2.2.1 so that the new tools (v3+) are not used during CI
